### PR TITLE
fix: declare compatibility with Nextcloud 34

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Manage routines associates to admin groups]]></description>
     <bugs>https://github.com/libresign/admin_group_manager/issues</bugs>
     <repository type="git">https://github.com/libresign/admin_group_manager</repository>
     <dependencies>
-        <nextcloud min-version="30" max-version="33"/>
+        <nextcloud min-version="30" max-version="34"/>
     </dependencies>
     <background-jobs>
         <job>OCA\AdminGroupManager\BackgroundJob\EnableAppsForGroup</job>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Manage routines associates to admin groups]]></description>
     <bugs>https://github.com/libresign/admin_group_manager/issues</bugs>
     <repository type="git">https://github.com/libresign/admin_group_manager</repository>
     <dependencies>
-        <nextcloud min-version="30" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
     <background-jobs>
         <job>OCA\AdminGroupManager\BackgroundJob\EnableAppsForGroup</job>


### PR DESCRIPTION
## Summary
- update app dependency metadata to allow Nextcloud 34
- this avoids manual `--force` enable during local/dev setup

## Change
- `appinfo/info.xml`: `<nextcloud min-version="30" max-version="34"/>`

## Why
The WooCommerce integration plugin relies on endpoints provided by this app (`/ocs/v2.php/apps/admin_group_manager/...`). On Nextcloud 34 the app was blocked by compatibility metadata (`max-version="33"`), causing endpoint 404 until force-enabled.
